### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,16 +10,16 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 alarmRepeat	KEYWORD2
-alarmOnce KEYWORD2
+alarmOnce	KEYWORD2
 timerRepeat	KEYWORD2
-timerOnce KEYWORD2
-delay KEYWORD2
+timerOnce	KEYWORD2
+delay	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################
-Alarm KEYWORD2
+Alarm	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-dtINVALID_ALARM_ID LITERAL1
-dtINVALID_TIME     LITERAL1
+dtINVALID_ALARM_ID	LITERAL1
+dtINVALID_TIME	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords